### PR TITLE
update name from gruvbox to gruvbox-flat

### DIFF
--- a/lua/gruvbox/util.lua
+++ b/lua/gruvbox/util.lua
@@ -130,7 +130,7 @@ end
 
 --- Delete the autocmds when the theme changes to something else
 function util.onColorScheme()
-  if vim.g.colors_name ~= "gruvbox" then
+  if vim.g.colors_name ~= "gruvbox-flat" then
     vim.cmd([[autocmd! gruvbox]])
     vim.cmd([[augroup! gruvbox]])
   end
@@ -142,7 +142,7 @@ function util.autocmds(config)
   vim.cmd([[  autocmd!]])
   vim.cmd([[  autocmd ColorScheme * lua require("gruvbox.util").onColorScheme()]])
   if config.dev then
-    vim.cmd([[  autocmd BufWritePost */lua/gruvbox/** nested colorscheme gruvbox]])
+    vim.cmd([[  autocmd BufWritePost */lua/gruvbox/** nested colorscheme gruvbox-flat]])
   end
   for _, sidebar in ipairs(config.sidebars) do
     if sidebar == "terminal" then
@@ -227,7 +227,7 @@ function util.load(theme)
   end
 
   vim.o.termguicolors = true
-  vim.g.colors_name = "gruvbox"
+  vim.g.colors_name = "gruvbox-flat"
   -- vim.api.nvim__set_hl_ns(ns)
   -- load base theme
   util.syntax(theme.base)


### PR DESCRIPTION
When loading the colorscheme from a lua function I found I was getting an error saying it was unable to find the theme 'gruvbox'. When I checked the util file I found some references to gruvbox that I updated to gruvbox-flat. After those changes the colorscheme loaded with no errors.