### PR TITLE
Align closer to gruvbox base16 highlighting

### DIFF
--- a/extras/alacritty_gruvbox_.yml
+++ b/extras/alacritty_gruvbox_.yml
@@ -13,7 +13,7 @@ colors:
     yellow:  '0xd8a657'
     blue:    '0x7daea3'
     magenta: '0xd3869b'
-    cyan:    '0x89b482'
+    aqua:    '0x89b482'
     white:   '0xd4be98'
 
   # Bright colors
@@ -24,11 +24,11 @@ colors:
     yellow:  '0xd8a657'
     blue:    '0x7daea3'
     magenta: '0xd3869b'
-    cyan:    '0x89b482'
+    aqua:    '0x89b482'
     white:   '0xd4be98'
 
   indexed_colors:
     - { index: 16, color: '0xe78a4e' }
     - { index: 17, color: '0xc14a4a' }
 
-  
+

--- a/lua/gruvbox/colors.lua
+++ b/lua/gruvbox/colors.lua
@@ -28,7 +28,7 @@ function M.setup(config)
     fg_gutter = "#5a524c",
     dark5 = "#5a524c",
     blue = "#7daea3",
-    cyan = "#89b482",
+    aqua = "#89b482",
     purple = "#d3869b",
     orange = "#e78a4e",
     orange2 = "#c35e0a";
@@ -86,7 +86,7 @@ function M.setup(config)
   colors.error = colors.red
   colors.warning = colors.yellow
   colors.info = colors.blue
-  colors.hint = colors.cyan
+  colors.hint = colors.aqua
 
   util.color_overrides(colors, config)
 

--- a/lua/gruvbox/colors.lua
+++ b/lua/gruvbox/colors.lua
@@ -31,10 +31,12 @@ function M.setup(config)
     cyan = "#89b482",
     purple = "#d3869b",
     orange = "#e78a4e",
+    orange2 = "#d65d0e";
     yellow = "#d8a657",
     yellow2 = "#b47109",
     bg_yellow = "#a96b2c",
     green = "#a9b665",
+    aqua = "#8ec07c",
     red = "#ea6962",
     red1 = "#c14a4a",
     black = "#1d2021",

--- a/lua/gruvbox/colors.lua
+++ b/lua/gruvbox/colors.lua
@@ -36,7 +36,6 @@ function M.setup(config)
     yellow2 = "#b47109",
     bg_yellow = "#a96b2c",
     green = "#a9b665",
-    aqua = "#8ec07c",
     red = "#ea6962",
     red1 = "#c14a4a",
     black = "#1d2021",

--- a/lua/gruvbox/colors.lua
+++ b/lua/gruvbox/colors.lua
@@ -31,7 +31,7 @@ function M.setup(config)
     cyan = "#89b482",
     purple = "#d3869b",
     orange = "#e78a4e",
-    orange2 = "#d65d0e";
+    orange2 = "#c35e0a";
     yellow = "#d8a657",
     yellow2 = "#b47109",
     bg_yellow = "#a96b2c",

--- a/lua/gruvbox/extra/alacritty.lua
+++ b/lua/gruvbox/extra/alacritty.lua
@@ -31,7 +31,7 @@ colors:
     yellow:  '${yellow}'
     blue:    '${blue}'
     magenta: '${purple}'
-    cyan:    '${cyan}'
+    aqua:    '${aqua}'
     white:   '${fg_dark}'
 
   # Bright colors
@@ -42,7 +42,7 @@ colors:
     yellow:  '${yellow}'
     blue:    '${blue}'
     magenta: '${purple}'
-    cyan:    '${cyan}'
+    aqua:    '${aqua}'
     white:   '${fg}'
 
   indexed_colors:

--- a/lua/gruvbox/extra/kitty.lua
+++ b/lua/gruvbox/extra/kitty.lua
@@ -33,7 +33,7 @@ function M.kitty(config)
   color3 ${yellow}
   color4 ${blue}
   color5 ${purple}
-  color6 ${cyan}
+  color6 ${aqua}
   color7 ${fg_dark}
 
   # bright
@@ -43,7 +43,7 @@ function M.kitty(config)
   color11 ${yellow}
   color12 ${blue}
   color13 ${purple}
-  color14 ${cyan}
+  color14 ${aqua}
   color15 ${fg}
 
   # extended colors

--- a/lua/gruvbox/theme.lua
+++ b/lua/gruvbox/theme.lua
@@ -97,10 +97,10 @@ function M.setup(config)
     -- Repeat        = { }, --   for, do, while, etc.
     -- Label         = { }, --    case, default, etc.
     Operator = { fg = c.red }, -- "sizeof", "+", "*", etc.
-    Keyword = { fg = c.cyan, style = config.keywordStyle }, --  any other keyword
+    Keyword = { fg = c.aqua, style = config.keywordStyle }, --  any other keyword
     -- Exception     = { }, --  try, catch, throw
 
-    PreProc = { fg = c.cyan }, -- (preferred) generic Preprocessor
+    PreProc = { fg = c.aqua }, -- (preferred) generic Preprocessor
     -- Include       = { }, --  preprocessor #include
     -- Define        = { }, --   preprocessor #define
     -- Macro         = { }, --    same as Define
@@ -199,14 +199,14 @@ function M.setup(config)
     TSNote = { fg = c.bg, bg = c.info },
     TSWarning = { fg = c.bg, bg = c.warning },
     TSDanger = { fg = c.bg, bg = c.error },
-    TSConstructor = { fg = c.cyan }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
+    TSConstructor = { fg = c.aqua }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
     -- TSConditional       = { };    -- For keywords related to conditionnals.
     TSConstant = { fg = c.yellow }, -- For constants
     -- TSConstBuiltin      = { };    -- For constant that are built in the language: `nil` in Lua.
     -- TSConstMacro        = { };    -- For constants that are defined by macros: `NULL` in C.
     -- TSError             = { };    -- For syntax/parser errors.
     -- TSException         = { };    -- For exception related keywords.
-    TSField = { fg = c.cyan }, -- For fields.
+    TSField = { fg = c.aqua }, -- For fields.
     -- TSFloat             = { };    -- For floats.
     -- TSFunction          = { };    -- For function (calls and definitions).
     -- TSFuncBuiltin       = { };    -- For builtin functions: `table.insert` in Lua.
@@ -234,7 +234,7 @@ function M.setup(config)
     -- TSType              = { };    -- For types.
     -- TSTypeBuiltin       = { };    -- For builtin types.
     TSVariable = { style = config.variableStyle }, -- Any variable name that does not have another highlight.
-    TSVariableBuiltin = { fg = c.cyan }, -- Variable names that are defined by the languages, like `this` or `self`.
+    TSVariableBuiltin = { fg = c.aqua }, -- Variable names that are defined by the languages, like `this` or `self`.
 
     TSTag = { fg = c.red }, -- Tags like html tag names.
     -- TSTagDelimiter      = { };    -- Tag delimiter like `<` `>` `/`

--- a/lua/gruvbox/theme.lua
+++ b/lua/gruvbox/theme.lua
@@ -126,7 +126,7 @@ function M.setup(config)
     -- Ignore = { }, -- (preferred) left blank, hidden  |hl-Ignore|
 
     Error = { fg = c.error }, -- (preferred) any erroneous construct
-    Todo = { bg = c.blue, fg = c.bg }, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+    Todo = { bg = c.yellow, fg = c.bg }, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
 
     qfLineNr = { fg = c.dark5 },
     qfFileName = { fg = c.blue },
@@ -199,7 +199,7 @@ function M.setup(config)
     TSNote = { fg = c.bg, bg = c.info },
     TSWarning = { fg = c.bg, bg = c.warning },
     TSDanger = { fg = c.bg, bg = c.error },
-    TSConstructor = { fg = c.red }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
+    TSConstructor = { fg = c.aqua }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
     -- TSConditional       = { };    -- For keywords related to conditionnals.
     TSConstant = { fg = c.yellow }, -- For constants
     -- TSConstBuiltin      = { };    -- For constant that are built in the language: `nil` in Lua.
@@ -211,7 +211,7 @@ function M.setup(config)
     -- TSFunction          = { };    -- For function (calls and definitions).
     -- TSFuncBuiltin       = { };    -- For builtin functions: `table.insert` in Lua.
     -- TSFuncMacro         = { };    -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
-    TSInclude = { fg = c.purple }, -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
+    TSInclude = { fg = c.blue }, -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
     TSKeyword = { fg = c.purple, style = config.keywordStyle }, -- For keywords that don't fall in previous categories.
     TSKeywordFunction = { fg = c.purple, style = config.functionStyle }, -- For keywords used to define a fuction.
     TSLabel = { fg = c.blue }, -- For labels: `label:` in C and `:label:` in Lua.
@@ -223,9 +223,9 @@ function M.setup(config)
     TSParameter = { fg = c.red }, -- For parameters of a function.
     -- TSParameterReference= { };    -- For references to parameters of a function.
     TSProperty = { fg = c.red }, -- Same as `TSField`.
-    TSPunctDelimiter = { fg = c.fg }, -- For delimiters ie: `.`
-    TSPunctBracket = { fg = c.fg_dark }, -- For brackets and parens.
-    TSPunctSpecial = { fg = c.fg }, -- For special punctutation that does not fall in the catagories before.
+    TSPunctDelimiter = { fg = c.red }, -- For delimiters ie: `.`
+    TSPunctBracket = { fg = c.orange2 }, -- For brackets and parens.
+    TSPunctSpecial = { fg = c.orang2 }, -- For special punctutation that does not fall in the catagories before.
     -- TSRepeat            = { };    -- For keywords related to loops.
     -- TSString            = { };    -- For strings.
     TSStringRegex = { fg = c.orange }, -- For regexes.
@@ -234,7 +234,7 @@ function M.setup(config)
     -- TSType              = { };    -- For types.
     -- TSTypeBuiltin       = { };    -- For builtin types.
     TSVariable = { style = config.variableStyle }, -- Any variable name that does not have another highlight.
-    TSVariableBuiltin = { fg = c.red }, -- Variable names that are defined by the languages, like `this` or `self`.
+    TSVariableBuiltin = { fg = c.aqua }, -- Variable names that are defined by the languages, like `this` or `self`.
 
     TSTag = { fg = c.red }, -- Tags like html tag names.
     -- TSTagDelimiter      = { };    -- Tag delimiter like `<` `>` `/`

--- a/lua/gruvbox/theme.lua
+++ b/lua/gruvbox/theme.lua
@@ -225,7 +225,7 @@ function M.setup(config)
     TSProperty = { fg = c.red }, -- Same as `TSField`.
     TSPunctDelimiter = { fg = c.red }, -- For delimiters ie: `.`
     TSPunctBracket = { fg = c.orange2 }, -- For brackets and parens.
-    TSPunctSpecial = { fg = c.orang2 }, -- For special punctutation that does not fall in the catagories before.
+    TSPunctSpecial = { fg = c.orange2 }, -- For special punctutation that does not fall in the catagories before.
     -- TSRepeat            = { };    -- For keywords related to loops.
     -- TSString            = { };    -- For strings.
     TSStringRegex = { fg = c.orange }, -- For regexes.

--- a/lua/gruvbox/theme.lua
+++ b/lua/gruvbox/theme.lua
@@ -199,7 +199,7 @@ function M.setup(config)
     TSNote = { fg = c.bg, bg = c.info },
     TSWarning = { fg = c.bg, bg = c.warning },
     TSDanger = { fg = c.bg, bg = c.error },
-    TSConstructor = { fg = c.aqua }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
+    TSConstructor = { fg = c.cyan }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
     -- TSConditional       = { };    -- For keywords related to conditionnals.
     TSConstant = { fg = c.yellow }, -- For constants
     -- TSConstBuiltin      = { };    -- For constant that are built in the language: `nil` in Lua.
@@ -234,7 +234,7 @@ function M.setup(config)
     -- TSType              = { };    -- For types.
     -- TSTypeBuiltin       = { };    -- For builtin types.
     TSVariable = { style = config.variableStyle }, -- Any variable name that does not have another highlight.
-    TSVariableBuiltin = { fg = c.aqua }, -- Variable names that are defined by the languages, like `this` or `self`.
+    TSVariableBuiltin = { fg = c.cyan }, -- Variable names that are defined by the languages, like `this` or `self`.
 
     TSTag = { fg = c.red }, -- Tags like html tag names.
     -- TSTagDelimiter      = { };    -- Tag delimiter like `<` `>` `/`

--- a/lua/gruvbox/util.lua
+++ b/lua/gruvbox/util.lua
@@ -198,8 +198,8 @@ function util.terminal(colors)
   vim.g.terminal_color_5 = colors.purple
   vim.g.terminal_color_13 = colors.purple
 
-  vim.g.terminal_color_6 = colors.cyan
-  vim.g.terminal_color_14 = colors.cyan
+  vim.g.terminal_color_6 = colors.aqua
+  vim.g.terminal_color_14 = colors.aqua
 
   if vim.o.background == "light" then
     for i = 0, 15, 1 do


### PR DESCRIPTION
First off, I would like to say thanks for working on this project!  I have really enjoyed the theme!

I have been a longtime user of the following colorscheme:
https://github.com/chriskempson/base16-vim/blob/master/colors/base16-gruvbox-dark-soft.vim

After switching to your theme, I noticed some differences with the treesitter syntax highlighting.  The base16 highlighting seemed to have a bit more variety in highlighting some of the elements with different colors, specifically the `this` keyword within TypeScript.

I have attached a handful of images below to demonstrate the differences.

base16 gruvbox dark soft
![base16-gruvbox-dark-soft](https://user-images.githubusercontent.com/8680565/120075158-26833280-c06e-11eb-8e29-b8e23b0f24fc.png)

gruvbox-flat as-is
![gruvbox-flat-as-is](https://user-images.githubusercontent.com/8680565/120075159-27b45f80-c06e-11eb-99fd-35900f4124f0.png)

gruvbox-flat to-be
![gruvbox-flat-to-be](https://user-images.githubusercontent.com/8680565/120075160-27b45f80-c06e-11eb-9e52-6989149db7b9.png)

One thing to note about my color selections within the PR is that I pulled them from https://github.com/morhetz/gruvbox for `orange2` and `aqua`.  I think they fit alright with your theme, but if you're using a flat calculation to find a new representation, then I can adjust them as you see fit.

Thanks again and interested to hear your thoughts!
