### PR TITLE
👔 Make the kitty tabs pop

### DIFF
--- a/extras/kitty_gruvbox_.conf
+++ b/extras/kitty_gruvbox_.conf
@@ -8,10 +8,10 @@
   cursor #d4be98
 
   # Tabs
-  active_tab_background #282828
-  active_tab_foreground #d4be98
+  active_tab_background #ea6962
+  active_tab_foreground #262627
   inactive_tab_background #45403d
-  inactive_tab_foreground #5a524c
+  inactive_tab_foreground #d4be98
   #tab_bar_background #262627
 
   # normal
@@ -37,4 +37,3 @@
   # extended colors
   color16 #e78a4e
   color17 #c14a4a
-  


### PR DESCRIPTION
**_Inactive kitty tabs_** are hard to see in the previous config, I changed the tab's **_foreground_** and **_background_** colors according to a color palette. That gives us a **unique contrast** for Inactive and active tabs.

### Previous

![Previous Kitty tab colors](https://imgur.com/S0BcqHa.png)

### Current

![Previous Kitty tab colors](https://imgur.com/HMMcsoN.png)
