### PR TITLE
Define 2 key colors for hop

### DIFF
--- a/lua/gruvbox/theme.lua
+++ b/lua/gruvbox/theme.lua
@@ -353,8 +353,11 @@ function M.setup(config)
     BufferLineFill = { bg = c.black },
 
     -- Hop
-    HopNextKey = { fg = c.red },
+    HopNextKey = { fg = c.red, style = "bold" },
+	HopNextKey1 = { fg = c.blue, style = "bold" },
+	HopNextKey2 = { fg = util.darken(c.blue, 0.80) },
     HopUnmatched = { fg = c.comment },
+
   }
 
   if config.hideInactiveStatusline then


### PR DESCRIPTION
The default blue color of hop looks out of place. Replaced it with gruvbox's blue color.

Before:
![Screenshot from 2021-08-16 09-05-18](https://user-images.githubusercontent.com/43147494/129508255-b28e2d74-5898-419d-8f29-08b11cffe4aa.png)

After:
![Screenshot from 2021-08-16 09-04-57](https://user-images.githubusercontent.com/43147494/129508270-ea1ad8a1-7765-4ec3-81e1-7f594d873670.png)
