### PR TITLE
Improve Telescope border colors

### DIFF
--- a/lua/gruvbox/theme.lua
+++ b/lua/gruvbox/theme.lua
@@ -289,9 +289,9 @@ function M.setup(config)
     GitSignsDelete = { fg = c.gitSigns.delete }, -- diff mode: Deleted line |diff.txt|
 
     -- Telescope
-    TelescopeBorder = { fg = c.border_highlight },
-    TelescopePromptBorder = { fg = c.prompt_border },
-    TelescopeResultsBorder = { fg = c.bg_highlight },
+    TelescopeBorder = { fg = util.darken(c.fg, 0.75) },
+    TelescopePromptBorder = { fg = c.fg_light },
+    TelescopeResultsBorder = { fg = util.darken(c.fg, 0.75) },
     TelescopeSelectionCaret = { fg = c.purple },
     TelescopeSelection = { fg = c.purple, bg = c.bg_highlight },
     TelescopeMatching = { fg = c.blue },


### PR DESCRIPTION
Right now the telescope border is very dark and it blends in with the background, I think replacing it with lighter color looks better. What do you think?

Before:
![Screenshot from 2021-08-16 09-22-09](https://user-images.githubusercontent.com/43147494/129509414-1fbcbeaf-0f21-4007-87c0-385dcb19d50a.png)

After:
![Screenshot from 2021-08-16 09-21-49](https://user-images.githubusercontent.com/43147494/129509430-35b92c54-ca07-4fec-b9f4-b8c7845c7dc4.png)
