### PR TITLE
Update lua query syntax

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -1,1 +1,2 @@
-(self) @variable.builtin
+((identifier) @variable.builtin
+ (#match? @variable.builtin "self"))


### PR DESCRIPTION
Treesitter 0.5+ update caused changes in treesitter syntax for queries. The current query causes errors due to undefined node in the query syntax.