### PR TITLE
fix: Adding `extends` keyword to scm queries per latest neovim changes to not break nvim-treesitter queries

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -1,2 +1,3 @@
+; extends
 ((identifier) @variable.builtin
  (#match? @variable.builtin "self"))

--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -1,1 +1,2 @@
+; extends
 "function" @keyword.function


### PR DESCRIPTION
@eddyekofo94 
fix: Adding `extends` keyword to scm queries per latest neovim changes to not break nvim-treesitter queries

Related to this neovim change for treesitter queries: https://github.com/neovim/neovim/pull/20105
And this nvim-treesitter issue: https://github.com/nvim-treesitter/nvim-treesitter/issues/3538#event-7528522877

If not added breaks lua and typescript highlighting if installed. 