### PR TITLE
fix: don't defer colorscheme setup

### DIFF
--- a/lua/gruvbox/theme.lua
+++ b/lua/gruvbox/theme.lua
@@ -358,6 +358,10 @@ function M.setup(config)
 	HopNextKey2 = { fg = util.darken(c.blue, 0.80) },
     HopUnmatched = { fg = c.comment },
 
+		-- ChooseWin
+		ChooseWinOther = { bg = c.bg_statusline },
+		ChooseWinLabelCurrent = { bg = util.lighten(c.blue, 0.7), fg = c.black, style = "bold" },
+		ChooseWinLabel = { bg = util.darken(c.blue, 0.9), fg = util.lighten(c.black, 0.8) },
   }
 
   if config.hideInactiveStatusline then

--- a/lua/gruvbox/util.lua
+++ b/lua/gruvbox/util.lua
@@ -203,11 +203,9 @@ function util.load(theme)
   util.syntax(theme.base)
 
   -- load syntax for plugins and terminal async
-  vim.defer_fn(function()
-    util.terminal(theme.colors)
-    util.syntax(theme.plugins)
-    util.autocmds(theme.config)
-  end, 0)
+  util.terminal(theme.colors)
+  util.syntax(theme.plugins)
+  util.autocmds(theme.config)
 
   -- link to new tree-sitter highlight groups
   if vim.fn.has('nvim-0.8.0') == 1 then


### PR DESCRIPTION
Deferring colorscheme setting is an unnecessary optimization that can cause bugs and confusion.

Fixes https://github.com/eddyekofo94/gruvbox-flat.nvim/issues/29.